### PR TITLE
url for esp-protocols - ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/revk/AXL
 [submodule "esp-protocols"]
 	path = esp-protocols
-	url = git@github.com:espressif/esp-protocols.git
+	url = https://github.com/espressif/esp-protocols


### PR DESCRIPTION
hi, git clone recursive give me this error, because of using ssh nor https for url

git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights and the repository exists. fatal: clone of 'git@github.com:espressif/esp-protocols.git' into submodule path 'C:/.../ESP32-Daikin/ESP32-Daikin/esp-protocols' failed