### PR TITLE
correct HA template

### DIFF
--- a/ESP/main/Faikout.c
+++ b/ESP/main/Faikout.c
@@ -2904,7 +2904,7 @@ send_ha_config (void)
       if (daikin.status_known & CONTROL_hum)
       {
          jo_string (j, "curr_hum_t", hastatus);
-         jo_string (j, "curr_hum_tpl", "{{value_json.humidity}}");
+         jo_string (j, "curr_hum_tpl", "{{value_json.hum}}");
       }
       if (daikin.status_known & CONTROL_mode)
       {


### PR DESCRIPTION
Fix mismatch between `hum` and `humidity` in HA template vs JSON.

Should fix https://github.com/revk/ESP32-Faikout/issues/915

I haven't tested this - can do in about 12 hours.